### PR TITLE
return empty array

### DIFF
--- a/resources/views/pages/list-activities.blade.php
+++ b/resources/views/pages/list-activities.blade.php
@@ -38,7 +38,7 @@
                             /* @var \Spatie\Activitylog\Models\Activity $activityItem */
                             $changes = $activityItem->getChangesAttribute();
                         @endphp
-                        @foreach(data_get($changes, 'attributes') as $field => $change)
+                        @foreach(data_get($changes, 'attributes') ?? [] as $field => $change)
                             <x-tables::row @class(['bg-gray-100/30' => $loop->even])>
                                 <x-tables::cell width="20%" class="px-4 py-2 align-top">
                                     {{ $this->getFieldLabel($field) }}

--- a/resources/views/pages/list-activities.blade.php
+++ b/resources/views/pages/list-activities.blade.php
@@ -38,7 +38,7 @@
                             /* @var \Spatie\Activitylog\Models\Activity $activityItem */
                             $changes = $activityItem->getChangesAttribute();
                         @endphp
-                        @foreach(data_get($changes, 'attributes') ?? [] as $field => $change)
+                        @foreach(data_get($changes, 'attributes', []) as $field => $change)
                             <x-tables::row @class(['bg-gray-100/30' => $loop->even])>
                                 <x-tables::cell width="20%" class="px-4 py-2 align-top">
                                     {{ $this->getFieldLabel($field) }}


### PR DESCRIPTION

This pull request addresses an important issue related to null attributes ;l;. 

Previously, when `data_get($changes, 'attributes')` returned null, it would result in a 500 error. To mitigate this issue, this pull request introduces a fix that returns an empty array when the attributes are null. This prevents the occurrence of errors and ensures smooth functionality.

For example, when using the `softDeletes` feature, if you attempt to retrieve information about the entity that was soft-deleted and the attributes are null, you would previously encounter an error message. However, with this fix in place, the code gracefully handles the null attributes and returns an empty array instead, preventing any disruptive errors.

Please review the changes made in this pull request and provide any feedback or suggestions. Your input is greatly appreciated. Thank you!
