### PR TITLE
fix(restoreActivity): Create JavaScript string from the activity item key

### DIFF
--- a/resources/views/pages/list-activities.blade.php
+++ b/resources/views/pages/list-activities.blade.php
@@ -26,7 +26,7 @@
                                     labeled-from="sm"
                                     color="gray"
                                     class="right"
-                                    wire:click="restoreActivity({{ $activityItem->getKey() }})"
+                                    wire:click="restoreActivity({{ Js::from($activityItem->getKey()) }})"
                                 >
                                     @lang('filament-activity-log::activities.table.restore')
                                 </x-filament::button>


### PR DESCRIPTION
This fix ensures that besides Integers also UUIDs can be passed into the restoreActivity Function.