### PR TITLE
fix: activities causer eager load

### DIFF
--- a/src/Pages/ListActivities.php
+++ b/src/Pages/ListActivities.php
@@ -44,7 +44,7 @@ abstract class ListActivities extends Page implements HasForms
     public function getActivities()
     {
         return $this->paginateTableQuery(
-            $this->record->activities()->latest()->getQuery()
+            $this->record->activities()->with('causer')->latest()->getQuery()
         );
     }
 


### PR DESCRIPTION
When you use [Preventing Lazy Loading](https://laravel.com/docs/10.x/eloquent-relationships#preventing-lazy-loading) configuration, activities resource page throw an Illuminate \ Database \ LazyLoadingViolationException.

To fix that, just add with('causer') after activities() call.

![image](https://github.com/pxlrbt/filament-activity-log/assets/6574025/4217676b-626a-47df-9b8d-793716dd99c9)
