### PR TITLE
Extract restore authorization

### DIFF
--- a/resources/views/pages/list-activities.blade.php
+++ b/resources/views/pages/list-activities.blade.php
@@ -22,7 +22,7 @@
                             </div>
                         </div>
                         <div class="flex flex-col text-xs text-gray-500 justify-end">
-                            @if (static::getResource()::canRestore($record))
+                            @if ($this->canRestoreActivity())
                                 <x-filament::button
                                     tag="button"
                                     icon="heroicon-o-arrow-path-rounded-square"

--- a/src/Pages/ListActivities.php
+++ b/src/Pages/ListActivities.php
@@ -87,9 +87,14 @@ abstract class ListActivities extends Page implements HasForms
             ]);
     }
 
+    public function canRestoreActivity(): bool
+    {
+        return static::getResource()::canRestore($this->record);
+    }
+
     public function restoreActivity(int|string $key)
     {
-        if (! static::getResource()::canRestore($this->record)) {
+        if (! $this->canRestoreActivity()) {
             abort(403);
         }
 


### PR DESCRIPTION
This PR extracts the authorization of the restore action to be able to use a different authorization method than `restore`. It fixes #38