### PR TITLE
Ensure we have fields for rendering restore and table.

### DIFF
--- a/resources/lang/ckb/activities.php
+++ b/resources/lang/ckb/activities.php
@@ -7,13 +7,13 @@ return [
     'title' => 'نرخەکانی پێشووی :record',
 
     'default_datetime_format' => 'Y-m-d, H:i:s',
-    
+
     'table' => [
         'field' => 'خانە',
         'old' => 'کۆن',
         'new' => 'نوێ',
     ],
-    
+
     'events' => [
         'updated' => 'نوێکراوەتەوە',
         'Created' => 'دروستکراوە',

--- a/resources/lang/ckb/activities.php
+++ b/resources/lang/ckb/activities.php
@@ -1,0 +1,25 @@
+<?php
+
+return [
+
+    'breadcrumb' => 'نرخی پێشوو',
+
+    'title' => 'نرخەکانی پێشووی :record',
+
+    'default_datetime_format' => 'Y-m-d, H:i:s',
+    
+    'table' => [
+        'field' => 'خانە',
+        'old' => 'کۆن',
+        'new' => 'نوێ',
+    ],
+    
+    'events' => [
+        'updated' => 'نوێکراوەتەوە',
+        'Created' => 'دروستکراوە',
+        'deleted' => 'سڕایەوە',
+        'restored' => 'گەڕاندنەوە',
+        'restore_successful' => 'بە سەرکەوتوویی گەڕێنرایەوە',
+        'restore_failed' => 'گەڕاندنەوە شکستی هێنا',
+    ],
+];

--- a/resources/lang/cs/activities.php
+++ b/resources/lang/cs/activities.php
@@ -1,0 +1,25 @@
+<?php
+
+return [
+    'breadcrumb' => 'Log',
+
+    'title' => 'Log entity ":record"',
+
+    'default_datetime_format' => 'j.n.Y H:i:s',
+
+    'table' => [
+        'field' => 'Pole',
+        'old' => 'Původní',
+        'new' => 'Nové',
+        'restore' => 'Obnovit',
+    ],
+
+    'events' => [
+        'updated' => 'Upraveno',
+        'created' => 'Vytvořeno',
+        'deleted' => 'Smazáno',
+        'restored' => 'Obnoveno',
+        'restore_successful' => 'Úspěšně obnoveno',
+        'restore_failed' => 'Obnovení selhalo',
+    ],
+];

--- a/resources/lang/fr/activities.php
+++ b/resources/lang/fr/activities.php
@@ -1,0 +1,25 @@
+<?php
+
+return [
+    'breadcrumb' => 'Historique',
+
+    'title' => 'Historique :record',
+
+    'default_datetime_format' => 'Y-m-d, H:i:s',
+
+    'table' => [
+        'field' => 'Champ',
+        'old' => 'Ancien',
+        'new' => 'Nouveau',
+        'restore' => 'Restaurer',
+    ],
+
+    'events' => [
+        'updated' => 'Mis à jour',
+        'created' => 'Créé',
+        'deleted' => 'Effacé',
+        'restored' => 'Restauré',
+        'restore_successful' => 'Restauré avec succès',
+        'restore_failed' => 'Échec de la restauration',
+    ],
+];

--- a/resources/lang/nl/activities.php
+++ b/resources/lang/nl/activities.php
@@ -1,0 +1,25 @@
+<?php
+
+return [
+    'breadcrumb' => 'Geschiedenis',
+
+    'title' => 'Geschiedenis :record',
+
+    'default_datetime_format' => 'Y-m-d, H:i:s',
+
+    'table' => [
+        'field' => 'Veld',
+        'old' => 'Oud',
+        'new' => 'Nieuw',
+        'restore' => 'Herstellen',
+    ],
+
+    'events' => [
+        'updated' => 'Bewerkt',
+        'created' => 'Aangemaakt',
+        'deleted' => 'Verwijderd',
+        'restored' => 'Hersteld',
+        'restore_successful' => 'Succesvol hersteld',
+        'restore_failed' => 'Herstellen mislukt',
+    ],
+];

--- a/resources/lang/pt_BR/activities.php
+++ b/resources/lang/pt_BR/activities.php
@@ -1,0 +1,25 @@
+<?php
+
+return [
+    'breadcrumb' => 'Histórico',
+
+    'title' => 'Histórico :record',
+
+    'default_datetime_format' => 'd/m/Y H:i:s',
+
+    'table' => [
+        'field' => 'Campo',
+        'old' => 'Antes',
+        'new' => 'Depois',
+        'restore' => 'Restaurado',
+    ],
+
+    'events' => [
+        'updated' => 'Atualizado',
+        'created' => 'Criado',
+        'deleted' => 'Excluído',
+        'restored' => 'Restaurado',
+        'restore_successful' => 'Restaurado com sucesso',
+        'restore_failed' => 'Falha na restauração',
+    ],
+];

--- a/resources/views/pages/list-activities.blade.php
+++ b/resources/views/pages/list-activities.blade.php
@@ -45,7 +45,7 @@
                     </div>
                 </div>
 
-                @if($changesCount > 0))
+                @if($changesCount > 0)
                                     
                 <x-filament-tables::table class="w-full overflow-hidden text-sm">
                     <x-slot:header>

--- a/resources/views/pages/list-activities.blade.php
+++ b/resources/views/pages/list-activities.blade.php
@@ -4,6 +4,13 @@
 <x-filament-panels::page>
     <div class="space-y-6">
         @foreach($this->getActivities() as $activityItem)
+
+            @php
+                /* @var \Spatie\Activitylog\Models\Activity $activityItem */
+                $changes = $activityItem->getChangesAttribute();
+                $changesCount = $changes->count();
+            @endphp
+        
             <div @class([
                 'p-2 space-y-2 bg-white rounded-xl shadow',
                 'dark:border-gray-600 dark:bg-gray-800',
@@ -22,7 +29,7 @@
                             </div>
                         </div>
                         <div class="flex flex-col text-xs text-gray-500 justify-end">
-                            @if ($this->canRestoreActivity())
+                            @if ($this->canRestoreActivity() && $changesCount > 0)
                                 <x-filament::button
                                     tag="button"
                                     icon="heroicon-o-arrow-path-rounded-square"
@@ -38,6 +45,8 @@
                     </div>
                 </div>
 
+                @if($changesCount > 0))
+                                    
                 <x-filament-tables::table class="w-full overflow-hidden text-sm">
                     <x-slot:header>
                         <x-filament-tables::header-cell>
@@ -80,6 +89,7 @@
                             </x-filament-tables::row>
                         @endforeach
                 </x-filament-tables::table>
+                @endif
             </div>
         @endforeach
 

--- a/resources/views/pages/list-activities.blade.php
+++ b/resources/views/pages/list-activities.blade.php
@@ -22,7 +22,7 @@
                             </div>
                         </div>
                         <div class="flex flex-col text-xs text-gray-500 justify-end">
-                            @if (static::getResource()::canRestore($record))
+                            @if ($this->canRestoreActivity())
                                 <x-filament::button
                                     tag="button"
                                     icon="heroicon-o-arrow-path-rounded-square"

--- a/resources/views/pages/list-activities.blade.php
+++ b/resources/views/pages/list-activities.blade.php
@@ -46,49 +46,48 @@
                 </div>
 
                 @if($changesCount > 0)
-                                    
-                <x-filament-tables::table class="w-full overflow-hidden text-sm">
-                    <x-slot:header>
-                        <x-filament-tables::header-cell>
-                            @lang('filament-activity-log::activities.table.field')
-                        </x-filament-tables::header-cell>
-                        <x-filament-tables::header-cell>
-                            @lang('filament-activity-log::activities.table.old')
-                        </x-filament-tables::header-cell>
-                        <x-filament-tables::header-cell>
-                            @lang('filament-activity-log::activities.table.new')
-                        </x-filament-tables::header-cell>
-                    </x-slot:header>
-                        @php
-                            /* @var \Spatie\Activitylog\Models\Activity $activityItem */
-                            $changes = $activityItem->getChangesAttribute();
-                        @endphp
-                        @foreach(data_get($changes, 'attributes', []) as $field => $change)
+                    <x-filament-tables::table class="w-full overflow-hidden text-sm">
+                        <x-slot:header>
+                            <x-filament-tables::header-cell>
+                                @lang('filament-activity-log::activities.table.field')
+                            </x-filament-tables::header-cell>
+                            <x-filament-tables::header-cell>
+                                @lang('filament-activity-log::activities.table.old')
+                            </x-filament-tables::header-cell>
+                            <x-filament-tables::header-cell>
+                                @lang('filament-activity-log::activities.table.new')
+                            </x-filament-tables::header-cell>
+                        </x-slot:header>
                             @php
-                                $oldValue = data_get($changes, "old.{$field}");
-                                $newValue = data_get($changes, "attributes.{$field}");
+                                /* @var \Spatie\Activitylog\Models\Activity $activityItem */
+                                $changes = $activityItem->getChangesAttribute();
                             @endphp
-                            <x-filament-tables::row @class(['bg-gray-100/30' => $loop->even])>
-                                <x-filament-tables::cell width="20%" class="px-4 py-2 align-top sm:first-of-type:ps-6 sm:last-of-type:pe-6">
-                                    {{ $this->getFieldLabel($field) }}
-                                </x-filament-tables::cell>
-                                <x-filament-tables::cell width="40%" class="px-4 py-2 align-top break-all whitespace-normal">
-                                    @if(is_array($oldValue))
-                                        <pre class="text-xs text-gray-500">{{ json_encode($oldValue, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) }}</pre>
-                                    @else
-                                        {{ $oldValue }}
-                                    @endif
-                                </x-filament-tables::cell>
-                                <x-filament-tables::cell width="40%" class="px-4 py-2 align-top break-all whitespace-normal">
-                                    @if(is_array($newValue))
-                                        <pre class="text-xs text-gray-500">{{ json_encode($newValue, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) }}</pre>
-                                    @else
-                                        {{ $newValue }}
-                                    @endif
-                                </x-filament-tables::cell>
-                            </x-filament-tables::row>
-                        @endforeach
-                </x-filament-tables::table>
+                            @foreach(data_get($changes, 'attributes', []) as $field => $change)
+                                @php
+                                    $oldValue = data_get($changes, "old.{$field}");
+                                    $newValue = data_get($changes, "attributes.{$field}");
+                                @endphp
+                                <x-filament-tables::row @class(['bg-gray-100/30' => $loop->even])>
+                                    <x-filament-tables::cell width="20%" class="px-4 py-2 align-top sm:first-of-type:ps-6 sm:last-of-type:pe-6">
+                                        {{ $this->getFieldLabel($field) }}
+                                    </x-filament-tables::cell>
+                                    <x-filament-tables::cell width="40%" class="px-4 py-2 align-top break-all whitespace-normal">
+                                        @if(is_array($oldValue))
+                                            <pre class="text-xs text-gray-500">{{ json_encode($oldValue, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) }}</pre>
+                                        @else
+                                            {{ $oldValue }}
+                                        @endif
+                                    </x-filament-tables::cell>
+                                    <x-filament-tables::cell width="40%" class="px-4 py-2 align-top break-all whitespace-normal">
+                                        @if(is_array($newValue))
+                                            <pre class="text-xs text-gray-500">{{ json_encode($newValue, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) }}</pre>
+                                        @else
+                                            {{ $newValue }}
+                                        @endif
+                                    </x-filament-tables::cell>
+                                </x-filament-tables::row>
+                            @endforeach
+                    </x-filament-tables::table>
                 @endif
             </div>
         @endforeach

--- a/resources/views/pages/list-activities.blade.php
+++ b/resources/views/pages/list-activities.blade.php
@@ -63,14 +63,14 @@
                                 <x-filament-tables::cell width="20%" class="px-4 py-2 align-top sm:first-of-type:ps-6 sm:last-of-type:pe-6">
                                     {{ $this->getFieldLabel($field) }}
                                 </x-filament-tables::cell>
-                                <x-filament-tables::cell width="40%" class="px-4 py-2 align-top break-all !whitespace-normal">
+                                <x-filament-tables::cell width="40%" class="px-4 py-2 align-top break-all whitespace-normal">
                                     @if(is_array($oldValue))
                                         <pre class="text-xs text-gray-500">{{ json_encode($oldValue, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) }}</pre>
                                     @else
                                         {{ $oldValue }}
                                     @endif
                                 </x-filament-tables::cell>
-                                <x-filament-tables::cell width="40%" class="px-4 py-2 align-top break-all !whitespace-normal">
+                                <x-filament-tables::cell width="40%" class="px-4 py-2 align-top break-all whitespace-normal">
                                     @if(is_array($newValue))
                                         <pre class="text-xs text-gray-500">{{ json_encode($newValue, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) }}</pre>
                                     @else

--- a/src/Pages/ListActivities.php
+++ b/src/Pages/ListActivities.php
@@ -87,9 +87,14 @@ abstract class ListActivities extends Page implements HasForms
             ]);
     }
 
+    public function canRestoreActivity(): bool
+    {
+        return static::getResource()::canRestore($this->record);
+    }
+
     public function restoreActivity(int|string $key)
     {
-        if (! static::getResource()::canRestore($this->record)) {
+        if (! $this->canRestoreActivity()) {
             abort(403);
         }
 


### PR DESCRIPTION
Sometimes you may have a view record for sensitive data, this ensures that we only render the table and the restore button when fields exist to be rendered.