### PR TITLE
Use french datetime format as default in french translations

### DIFF
--- a/resources/lang/fr/activities.php
+++ b/resources/lang/fr/activities.php
@@ -5,7 +5,7 @@ return [
 
     'title' => 'Historique :record',
 
-    'default_datetime_format' => 'Y-m-d, H:i:s',
+    'default_datetime_format' => 'd/m/Y, H:i:s',
 
     'table' => [
         'field' => 'Champ',


### PR DESCRIPTION
Source if needed: https://en.wikipedia.org/wiki/Date_and_time_notation_in_France.