### PR TITLE
fix error:  Correctly handle relational attributes

### DIFF
--- a/resources/views/pages/list-activities.blade.php
+++ b/resources/views/pages/list-activities.blade.php
@@ -59,8 +59,8 @@
                         </x-slot:header>
                             @foreach (data_get($changes, 'attributes', []) as $field => $change)
                                 @php
-                                    $oldValue = data_get($changes, "old.{$field}");
-                                    $newValue = data_get($changes, "attributes.{$field}");
+                                    $oldValue = isset($changes['old'][$field]) ? $changes['old'][$field] : '';
+                                    $newValue = isset($changes['attributes'][$field]) ? $changes['attributes'][$field] : ''; 
                                 @endphp
                                 <x-filament-tables::row @class(['bg-gray-100/30' => $loop->even])>
                                     <x-filament-tables::cell width="20%" class="px-4 py-2 align-top sm:first-of-type:ps-6 sm:last-of-type:pe-6">


### PR DESCRIPTION
Addressed an issue where `data_get` failed to retrieve values from related models using dot notation in Spatie logging. Switched to `isset` checks to correctly capture and log old and new values of relationship attributes.