### PR TITLE
Add Traditional Chinese (zh_TW) translation for activity log

### DIFF
--- a/resources/lang/zh_TW/activities.php
+++ b/resources/lang/zh_TW/activities.php
@@ -1,0 +1,25 @@
+<?php
+
+return [
+    'breadcrumb' => '歷史記錄',
+
+    'title' => '歷史記錄：:record',
+
+    'default_datetime_format' => 'Y-m-d H:i:s',
+
+    'table' => [
+        'field' => '欄位',
+        'old' => '舊值',
+        'new' => '新值',
+        'restore' => '還原',
+    ],
+
+    'events' => [
+        'updated' => '已更新',
+        'created' => '已建立',
+        'deleted' => '已刪除',
+        'restored' => '已還原',
+        'restore_successful' => '還原成功',
+        'restore_failed' => '還原失敗',
+    ],
+];


### PR DESCRIPTION
Translate Filament activity log interface to Traditional Chinese, including history page title, table fields, and event status messages.