### PR TITLE
#67 Rename aliased resetLivewirePage to resetPage

### DIFF
--- a/src/Pages/Concerns/CanPaginate.php
+++ b/src/Pages/Concerns/CanPaginate.php
@@ -23,7 +23,7 @@ trait CanPaginate
             $this->getPerPageSessionKey() => $this->getRecordsPerPage(),
         ]);
 
-        $this->resetLivewirePage();
+        $this->resetPage();
     }
 
     protected function paginateQuery(Builder $query): Paginator|CursorPaginator


### PR DESCRIPTION
In previous versions this method was aliased within `ListActivites.php` via the `WithPagination` trait.

Right now with the removal of the alias a method not found is being thrown.

This doesn't revert the change in the changelog but will remove the alias all together.

Only other instance I can see of that alias being used is within Filament's `InteractsWithTable` concern.